### PR TITLE
Trim special characters from the ends of card names

### DIFF
--- a/OCTGNDeckConverter/Model/ConverterCard.cs
+++ b/OCTGNDeckConverter/Model/ConverterCard.cs
@@ -31,7 +31,7 @@ namespace OCTGNDeckConverter.Model
             }
 
             this.CardID = cardID;
-            this.Name = name;
+            this.Name = name.Trim(new Char[] { '{', '}', '[', ']', '<', '>', '_', '^', '*', ' '});
             this.Set = set;
             this.MultiverseID = multiverseID;
         }


### PR DESCRIPTION
This fix is for Call of Cthulhu specifically.  If any other games use
those characters, a per game system solution might be in order.
