### PR TITLE
Get install path for octgn

### DIFF
--- a/installer/InstallScript.nsi
+++ b/installer/InstallScript.nsi
@@ -52,7 +52,8 @@ RequestExecutionLevel user
 Section "" ; No components page, name is not important
 
 	ClearErrors
-	FileOpen $0 $APPDATA\..\Local\Programs\OCTGN\data.path r
+	ReadRegStr $2 HKCU "SOFTWARE\OCTGN" 'InstallPath'
+	FileOpen $0 "$2\data.path" r
 		IfErrors error
 	FileRead $0 $1
 	FileClose $0


### PR DESCRIPTION
This, _hopefully_ reads the registry to check for non-default install path to find `data.path`. 
I've not worked with NSIS before, so check me on it.
(also apparently github really wanted that newline at EOF)